### PR TITLE
Add header on demand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "name": "gocanto/http-client",
     "homepage": "https://github.com/gocanto/http-client",
     "type": "php-bundle",
-    "description": "Http client that handles retries & logging.",
+    "description": "Http client that handles retries, logging & dynamic headers.",
     "minimum-stability": "dev",
     "prefer-stable": true,
     "keywords": [

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -215,6 +215,11 @@ class HttpClient extends Client
             ) {
                 foreach ($headers as $name => $value) {
                     $request = $request->withHeader($name, $value);
+
+//                    $this->getLogger()->info('The header added.', [
+//                        'name' => $name,
+//                        'value' => $value,
+//                    ]);
                 }
 
                 return $handler($request, $options);
@@ -223,7 +228,7 @@ class HttpClient extends Client
 
         /** @var HandlerStack $handler */
         $handler = $this->getConfig('handler');
-        $handler->push($middleware);
+        $handler->push($middleware, 'dynamic_headers');
 
         $config = $this->getConfig();
         $config['handler'] = $handler;

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -27,7 +27,7 @@ use Psr\Log\NullLogger;
 
 class HttpClient extends Client
 {
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.1.0';
 
     /** @var LoggerInterface */
     private $logger;

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -19,10 +19,9 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\TransferStats;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -90,8 +89,8 @@ class HttpClient extends Client
 
         $decider = function (
             $retries,
-            Request $request,
-            Response $response = null,
+            RequestInterface $request,
+            ResponseInterface $response = null,
             RequestException $exception = null
         ) use (
             $callback,
@@ -121,8 +120,8 @@ class HttpClient extends Client
     {
         return function (
             $retries,
-            Request $request,
-            Response $response = null,
+            RequestInterface $request,
+            ResponseInterface $response = null,
             RequestException $exception = null
         ) use (
             $retryTotal
@@ -152,17 +151,17 @@ class HttpClient extends Client
     }
 
     /**
-     * @param Request $request
+     * @param RequestInterface $request
      * @param int $retries
      * @param int $retryTotal
-     * @param Response|null $response
+     * @param ResponseInterface|null $response
      * @param RequestException|null $exception
      */
     private function warning(
-        Request $request,
+        RequestInterface $request,
         int $retries,
         int $retryTotal,
-        ?Response $response,
+        ?ResponseInterface $response,
         ?RequestException $exception
     ): void {
         $this->getLogger()->warning(

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -1,6 +1,9 @@
 <?php
+
+declare(strict_types=1);
+
 /*
- * This file is part of the Gocanto better-http-client
+ * This file is part of the Gocanto http-client package.
  *
  * (c) Gustavo Ocanto <gustavoocanto@gmail.com>
  *

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -215,11 +215,6 @@ class HttpClient extends Client
             ) {
                 foreach ($headers as $name => $value) {
                     $request = $request->withHeader($name, $value);
-
-//                    $this->getLogger()->info('The header added.', [
-//                        'name' => $name,
-//                        'value' => $value,
-//                    ]);
                 }
 
                 return $handler($request, $options);

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Gocanto http-client package.
+ *
+ * (c) Gustavo Ocanto <gustavoocanto@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Tests\Unit\Http;
 
 use Gocanto\HttpClient\HttpClient;

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Tests\Unit\Http;
 
 use Gocanto\HttpClient\HttpClient;
@@ -40,6 +43,27 @@ class HttpClientTest extends TestCase
             ->request('GET', 'http://non-existent.example.com');
 
         $this->assertInstanceOf(LoggerInterface::class, $client->getLogger());
+    }
+
+    /**
+     * @test
+     * @throws GuzzleException
+     */
+    public function itAllowsSettingHeadersOnDemand()
+    {
+        $stream = fopen('php://temp', 'r+');
+        $client = new HttpClient(['debug' => $stream]);
+
+        $client->withHeaders([
+            'X-GUS-1' => 'gustavo',
+            'X-GUS-2' => 'ocanto',
+        ])->head('google.com');
+
+        fseek($stream, 0);
+        $output = stream_get_contents($stream);
+
+        $this->assertStringContainsString('X-GUS-1: gustavo', $output);
+        $this->assertStringContainsString('X-GUS-2: ocanto', $output);
     }
 
     /**

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -17,10 +17,10 @@ use Gocanto\HttpClient\HttpClient;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
 use Mockery;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -100,8 +100,8 @@ class HttpClientTest extends TestCase
     {
         return function (
             $retries,
-            Request $request,
-            Response $response = null,
+            RequestInterface $request,
+            ResponseInterface $response = null,
             RequestException $exception = null
         ) use (
             $retryTotal


### PR DESCRIPTION
Sometimes, we need to add headers to a given `client` instance based on dynamic data. 

Such as requirement is not possible on the creation stage because we do not know what information we would be dealing with. Therefore, we need a mechanism to hook into and populate this data when needed. 

This `PR` adds a new method [withHeaders](https://github.com/gocanto/http-client/commit/273deba06ccd1a10a7c0762ed3436ebb222f7839) to allow on-demand headers values whenever needed. 

For instance, you would be able to do something like so:

```php
$client = new HttpClient;

$client->withHeaders([
      'X-GUS-1' => 'testing testing',
      'X-GUS-2' => 'testing testing',
      'X-GUS-3' => 'testing testing',
      'X-GUS-4' => 'testing testing',
])->request('GET', 'https://foo.com');
```
to populate as many headers as needed. 

### Note
You can still call other methods on the client because of the immutability nature of the given method.
